### PR TITLE
ATSW2.xml: FIX _G nil error in OnEnter (cant see local _G)

### DIFF
--- a/AdvancedTradeSkillWindow2.xml
+++ b/AdvancedTradeSkillWindow2.xml
@@ -54,11 +54,19 @@
 					Highlight:Hide()
 				end
 				
-				local Button = _G[this:GetName()]
-			
-				local R, G, B = Button:GetTextColor()
 				
+<!-- old code disabled. cant see local _G var from ATDK2.lua (attempt to index global '_G' a nil value)
+				local Button = _G[this:GetName()]
+				local R, G, B = Button:GetTextColor()
 				ATSWHighlightMouseOver:SetPoint('TOP', Button)
+				-->
+				
+				
+<!-- new code. we use 'this' directly -->
+				local R, G, B = this:GetTextColor()
+				ATSWHighlightMouseOver:SetPoint('TOP', this)
+				
+				
 				ATSWHighlightMouseOverTexture:SetVertexColor(R, G, B, 0.8)
 				ATSWHighlightMouseOver:Show()
 			</OnEnter>
@@ -2896,4 +2904,5 @@
 			</OnLoad>
 		</Scripts>
 	</GameTooltip>
+
 </Ui>


### PR DESCRIPTION
fixes a '_G nil' scope boundary violation related error in OnEnter since ATSW2.xml was attempting to access a local from ATSW2.lua. we are using 'this' directly instead.